### PR TITLE
learnt useRef() to add focus state to textarea when game starts

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,7 +2,7 @@
 
 html {
   /* Colors */
-  --primary-clr: rgb(49, 150, 105);
+  --primary-clr: hsl(153, 51%, 39%);
   --dark-clr: rgb(12, 14, 24);
 
   /* Fonts */
@@ -69,8 +69,12 @@ button {
   background: var(--primary-clr);
   padding: 0.5em var(--padding-small);
   text-transform: uppercase;
+  cursor: pointer;
 }
 
+button:disabled {
+  cursor: not-allowed;
+}
 
 textarea {
   font-family: var(--ff-reg);
@@ -87,4 +91,8 @@ textarea {
 
 textarea:focus {
   border: 3px solid firebrick;
+}
+
+textarea:disabled {
+  background-color: #a5a2a2;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import "./App.css";
 
 function App() {
@@ -8,7 +8,7 @@ function App() {
   const [wordCount, setWordCount] = useState(0);
   const [isTimeRunning, setIsTimeRunning] = useState(false)
   const [timeRemaining, setTimeRemaining] = useState(TIME_OF_GAME);
-  const [disableBtn, setDisableBtn] = useState(false);
+  const textareaRef = useRef(null)
 
   function handleChange(event) {
     const { value } = event.target;
@@ -27,18 +27,18 @@ function App() {
     }
   }
 
-  function handleStartTimer() {
+  function handleGameStart() {
+    textareaRef.current.disabled = false
+    textareaRef.current.focus()
     setIsTimeRunning(true)
     setTypedText("")
-    setWordCount(0)
+    // setWordCount(0) - only use if you want to reset the high score
     setTimeRemaining(TIME_OF_GAME)
-    setDisableBtn(true)
   }
 
-  function handleEndTimer() {
+  function handleGameEnd() {
     countWords(typedText)
     setIsTimeRunning(false)
-    setDisableBtn(false)
   }
 
   useEffect(() => {
@@ -47,16 +47,16 @@ function App() {
         setTimeRemaining(prevtime => prevtime - 1)
       }, 1000)
     } else if(timeRemaining === 0) {
-      handleEndTimer()
+      handleGameEnd()
     }
   }, [isTimeRunning, timeRemaining])
 
   return (
     <div>
       <h1>Speed Typing Game</h1>
-      <textarea onChange={handleChange} value={typedText} />
+      <textarea ref={textareaRef} disabled={!isTimeRunning} onChange={handleChange} value={typedText} />
       <h4>Time reminaing: {timeRemaining}</h4>
-      <button disabled={disableBtn} onClick={handleStartTimer}>Start</button>
+      <button disabled={isTimeRunning} onClick={handleGameStart}>Start</button>
       <h1>Word count: {wordCount}</h1>
     </div>
   );


### PR DESCRIPTION
Final bug fix - when user started game they needed to tap/click into the textarea to type. Learnt useRef() hook to grab textarea element and have it automatically focus on game start.